### PR TITLE
arm: brain: disable RTC

### DIFF
--- a/arch/arm/boot/dts/imx28-brain.dtsi
+++ b/arch/arm/boot/dts/imx28-brain.dtsi
@@ -207,6 +207,10 @@
 				fsl,settling = <10>;
 			};
 
+			mxs_rtc: rtc@80056000 {
+				status = "disabled";
+			};
+
 			i2c0: i2c@80058000 {
 				pinctrl-names = "default";
 				pinctrl-0 = <&i2c0_pins_a>;


### PR DESCRIPTION
The RTC is not effective to save the clock since it has no RTC battery