### PR TITLE
arm: fix typo in filename

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -693,7 +693,7 @@ dtb-$(CONFIG_SOC_IMX7ULP) += \
 	imx7ulp-evkb-mipi.dtb \
 	imx7ulp-evkb-rm68200-wxga.dtb \
 	imx7ulp-evkb-rm68191-qhd.dtb \
-	imx7ulp-pwh1.dts
+	imx7ulp-pwh1.dtb
 dtb-$(CONFIG_SOC_LS1021A) += \
 	ls1021a-moxa-uc-8410a.dtb \
 	ls1021a-qds.dtb \


### PR DESCRIPTION
imx7ulp-pwh1.dtbファイルが生成されない問題の修正