### PR TITLE
input: keyboard: add completely support for PW-G5300 keymap

### DIFF
--- a/arch/arm/boot/dts/imx28-pwg5300.dts
+++ b/arch/arm/boot/dts/imx28-pwg5300.dts
@@ -27,16 +27,18 @@
 
 &keyboard_i2c {
 	status = "okay";
+	symbol-keycode = <0x0c>;  /* Page Down */
 	keymap =
-		<0x01 KEY_POWER>,     /* Power */
-		<0x07 KEY_ESC>,       /* Search */
-		<0x0d KEY_TAB>,       /* Kokugo */
-		<0x11 KEY_PAGEUP>,    /* Eiwa Waei */
-		<0x15 KEY_PAGEDOWN>,  /* My Dictionary */
-		<0x25 KEY_INSERT>,    /* History / Bookmark */
-		<0x1d KEY_DELETE>,    /* Marker test */
-		/* <0x2b Memorization tool> */
-		/* <0x24 Home> */
+		<0x01 KEY_POWER>,     /* Power On / Off */
+		<0x07 KEY_ESC>,       /* Global Search */
+		<0x0d KEY_TAB>,       /* Daijirin */
+		<0x11 KEY_PAGEUP>,    /* Eiwa / Waei */
+		<0x15 KEY_PAGEDOWN>,  /* Kogo */
+		<0x1c KEY_INSERT>,    /* Britannica */
+		<0x1d KEY_DELETE>,    /* Switch */
+		/* <0x25 >, */        /* Bookmark */
+		/* <0x24 >, */        /* Home */
+		/* <0x2b >, */        /* Dictionary Menu */
 		<0x02 KEY_Q>,         /* Q */
 		<0x08 KEY_W>,         /* W */
 		<0x0e KEY_E>,         /* E */
@@ -56,7 +58,7 @@
 		<0x20 KEY_J>,         /* J */
 		<0x28 KEY_K>,         /* K */
 		<0x2e KEY_L>,         /* L */
-		<0x05 KEY_LEFTSHIFT>,
+		<0x05 KEY_LEFTSHIFT>, /* Function */
 		<0x04 KEY_Z>,         /* Z */
 		<0x0a KEY_X>,         /* X */
 		<0x10 KEY_C>,         /* C */
@@ -65,26 +67,28 @@
 		<0x21 KEY_N>,         /* N */
 		<0x29 KEY_M>,         /* M */
 		<0x2f KEY_MINUS>,     /* Minus */
-		<0x31 KEY_BACKSPACE>, /* Backspace */
-		<0x0b KEY_LEFTCTRL>, /* Page Up */
-		/* <0x0c KEY_PAGEDOWN>, */ /* Page Down */
-		<0x06 KEY_LEFTALT>, /* Switch characters */
-		/* < 0x19, Symbols>, */
+		<0x31 KEY_BACKSPACE>, /* Backward */
+		<0x06 KEY_LEFTCTRL>,  /* Audio */
+		<0x0b KEY_LEFTALT>,   /* Page Up */
+		/* <0x0c Symbol>, */  /* Page Down */
+		<0x19 KEY_SPACE>,     /* S Jump */
 		<0x1b KEY_ESC>,       /* Go Back */
-		<0x1c KEY_SPACE>,     /* Space */
-		<0x23 KEY_ENTER>,     /* Enter */
+		<0x23 KEY_ENTER>,     /* Search / Enter */
 		<0x1a KEY_LEFT>,      /* Left */
 		<0x22 KEY_UP>,        /* Up */
 		<0x2a KEY_DOWN>,      /* Down */
 		<0x30 KEY_RIGHT>;     /* Right */
 	keymap-symbol =
-		<0x01 KEY_POWER>,      /* Power */
-		<0x07 KEY_ESC>,        /* Search */
-		<0x0d KEY_TAB>,        /* Kokugo */
-		<0x11 KEY_PAGEUP>,     /* Eiwa Waei */
-		<0x15 KEY_PAGEDOWN>,   /* My Dictionary */
-		<0x25 KEY_INSERT>,     /* History / Bookmark */
-		<0x1d KEY_DELETE>,     /* Marker test */
+		<0x01 KEY_POWER>,     /* Power On / Off */
+		<0x07 KEY_ESC>,       /* Global Search */
+		<0x0d KEY_TAB>,       /* Daijirin */
+		<0x11 KEY_PAGEUP>,    /* Eiwa / Waei */
+		<0x15 KEY_PAGEDOWN>,  /* Kogo */
+		<0x1c KEY_INSERT>,    /* Britannica */
+		<0x1d KEY_DELETE>,    /* Switch */
+		/* <0x25 >, */        /* Bookmark */
+		/* <0x24 >, */        /* Home */
+		/* <0x2b >, */        /* Dictionary Menu */
 		<0x02 KEY_1>,          /* Q */
 		<0x08 KEY_2>,          /* W */
 		<0x0e KEY_3>,          /* E */
@@ -102,12 +106,11 @@
 		<0x20 KEY_APOSTROPHE>, /* J */
 		<0x28 KEY_LEFTBRACE>,  /* K */
 		<0x2e KEY_RIGHTBRACE>, /* L */
-		<0x05 KEY_LEFTSHIFT>,
+		<0x05 KEY_LEFTSHIFT>,  /* Function */
 		<0x21 KEY_COMMA>,      /* N */
 		<0x29 KEY_DOT>,        /* M */
 		<0x2f KEY_SLASH>,      /* Minus */
-		<0x31 KEY_BACKSPACE>,  /* Backspace */
-		<0x0b KEY_LEFTCTRL>,   /* Page Up */
-		/* <0x0c KEY_PAGEDOWN>, */ /* Page Down */
-		<0x06 KEY_LEFTALT>;  /* Switch characters */
+		<0x31 KEY_BACKSPACE>,  /* Backward */
+		<0x06 KEY_LEFTCTRL>,   /* Audio */
+		<0x0b KEY_LEFTALT>;    /* Page Up */
 };

--- a/drivers/input/keyboard/brain-kbd-i2c.c
+++ b/drivers/input/keyboard/brain-kbd-i2c.c
@@ -38,13 +38,14 @@ struct bk_i2c_data {
 	int kmlen_symbol;
 
 	bool symbol;
+	u32 symbol_keycode;
 };
 
 static bool detect_key(struct bk_i2c_data *kbd, u8 keycode)
 {
 	int i;
 
-	if ((keycode & 0x3f) == 0x19) {
+	if ((keycode & 0x3f) == (u8)(kbd->symbol_keycode)) {
 		if (BK_IS_PRESSED(keycode)) {
 			dev_dbg(&kbd->cli->dev, "symbol pressed!\n");
 			kbd->symbol = true;
@@ -152,6 +153,11 @@ static int bk_i2c_probe(struct i2c_client *cli, const struct i2c_device_id *id)
 	kbd = devm_kzalloc(&cli->dev, sizeof(*kbd), GFP_KERNEL);
 	if (!kbd) {
 		return -ENOMEM;
+	}
+
+	if (of_property_read_u32(cli->dev.of_node,
+			"symbol-keycode", &kbd->symbol_keycode)) {
+		kbd->symbol_keycode = 0x19;
 	}
 
 	cells = 2;


### PR DESCRIPTION
- imx28-pwg5300.dts: add completely keymap for PW-G5300 (based on PW-SH1 keymap)
- brain-kbd-i2c.c: add `symbol-keycode`  devicetree property