### PR TITLE
Fix PW-A7400 device support

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -744,6 +744,7 @@ dtb-$(CONFIG_ARCH_MXS) += \
 	imx28-ts4600.dtb \
 	imx28-tx28.dtb \
 	imx28-pwa7200.dtb \
+	imx28-pwa7400.dtb \
 	imx28-pwsh1.dtb \
 	imx28-pwsh2.dtb \
 	imx28-pwsh3.dtb \

--- a/arch/arm/boot/dts/imx28-pwa7400.dts
+++ b/arch/arm/boot/dts/imx28-pwa7400.dts
@@ -7,11 +7,8 @@
 #include "imx28-brain.dtsi"
 
 / {
-	// Compatible with:
-	//     PW-G4200, PW-G5200, PW-G5300, PW-A7200, PW-A7300,
-	//     PW-A9100, PW-A9200, PW-A9300
-	model = "SHARP Brain PW-A7200 series";
-	compatible = "sharp,pw-a7200", "sharp,brain", "fsl,imx28";
+	model = "SHARP Brain PW-A7400";
+	compatible = "sharp,pw-a7400", "sharp,brain", "fsl,imx28";
 };
 
 &ssp2 {
@@ -22,16 +19,12 @@
 	status = "disabled";
 };
 
-&i2c1 {
-	status = "disabled";
-};
-
 &pwm {
 	pinctrl-0 = <&lcd_backlight_pins &slcd_backlight_pin &buzzer_pins>;
 };
 
 &duart {
-	pinctrl-0 = <&duart_pins_a>;
+	status = "disabled";
 };
 
 &brainlcd {
@@ -54,7 +47,7 @@
 	status = "okay";
 };
 
-&keyboard_i2c_2g {
+&keyboard_i2c {
 	status = "okay";
 	symbol-keycode = <0x0c>;  /* Page Down */
 	keymap =


### PR DESCRIPTION
The architecture of  PW-A7400 differs from the PW-A7200 series in I2C1 bus.
- the keyboard is connected by I2C1 bus.
- DUART is disabled due to pin conflict with I2C1 bus.