### PR TITLE
Fix the Shift & Symbol key issue on GPIO-based keyboards

### DIFF
--- a/arch/arm/boot/dts/imx28-brain.dtsi
+++ b/arch/arm/boot/dts/imx28-brain.dtsi
@@ -153,6 +153,32 @@
 					fsl,pull-up = <MXS_PULL_DISABLE>;
 				};
 
+				kbd_in_pins: keyboard@0 {
+					reg = <0>;
+					/*
+					 * Keyboard matrix sense (row) lines.
+					 * They are scanned by driving one column
+					 * low at a time while the others are kept
+					 * hi-Z, so the rows need a pull-up to
+					 * define the idle ("not pressed") level
+					 * and to avoid floating reads. A pressed
+					 * key pulls its row low.
+					 */
+					fsl,pinmux-ids = <
+						MX28_PAD_ENET0_MDC__GPIO_4_0
+						MX28_PAD_ENET0_MDIO__GPIO_4_1
+						MX28_PAD_ENET0_RX_EN__GPIO_4_2
+						MX28_PAD_ENET0_RXD0__GPIO_4_3
+						MX28_PAD_ENET0_RXD1__GPIO_4_4
+						MX28_PAD_ENET0_TX_CLK__GPIO_4_5
+						MX28_PAD_ENET0_TX_EN__GPIO_4_6
+						MX28_PAD_ENET0_TXD0__GPIO_4_7
+					>;
+					fsl,drive-strength = <MXS_DRIVE_4mA>;
+					fsl,voltage = <MXS_VOLTAGE_HIGH>;
+					fsl,pull-up = <MXS_PULL_ENABLE>;
+				};
+
 				lcd_backlight_pins: pwm@0 {
 					reg = <0>;
 					fsl,pinmux-ids = <
@@ -392,6 +418,8 @@
 	keyboard_gpio: keyboard_gpio {
 		status = "disabled";
 		compatible = "sharp,brain-kbd-gpio";
+		pinctrl-names = "default";
+		pinctrl-0 = <&kbd_in_pins>;
 	};
 
 	buzzer_cold: buzzer_cold {

--- a/drivers/input/keyboard/brain-kbd-gpio.c
+++ b/drivers/input/keyboard/brain-kbd-gpio.c
@@ -149,6 +149,24 @@ static void bk_gpio_poll(struct input_dev *inputdev)
 					}
 					kbd->pressed[i][j] = true;
 				} else {
+					/*
+					 * Key released while its bank is still
+					 * active (e.g. another key in the same
+					 * bank is held, as in a modifier chord).
+					 * Emit the release here; the bank-flush
+					 * branch below only runs once the WHOLE
+					 * bank goes idle, so without this a key
+					 * lifted mid-chord would stick.
+					 */
+					if (kbd->pressed[i][j]) {
+						if (i == kbd->sym_key_bank && j == kbd->sym_key_num) {
+							kbd->symbol = false;
+						} else {
+							dev_dbg(dev, "R: %04x\n", kbd->km[i][j]);
+							input_report_key(inputdev, kbd->km[i][j], 0);
+							input_report_key(inputdev, kbd->km_symbol[i][j], 0);
+						}
+					}
 					kbd->pressed[i][j] = false;
 				}
 			}

--- a/drivers/input/keyboard/brain-kbd-gpio.c
+++ b/drivers/input/keyboard/brain-kbd-gpio.c
@@ -48,15 +48,30 @@ static void bk_gpio_read_keys(struct input_dev *inputdev, ulong* result)
 
 	for (try = 0; try < ARRAY_SIZE(in); try++) {
 		for (i = 0; i < ARRAY_SIZE(in[0]); i++) {
-			gpiod_set_value(kbd->out[i], 1);
+			/*
+			 * Drive only the scanned column low and leave every
+			 * other column in high-impedance (input) mode. The
+			 * sense (row) lines are pulled up in the device tree,
+			 * so a pressed key pulls its row low. Keeping the other
+			 * columns hi-Z (instead of driving them low) prevents a
+			 * key held on another column from shorting a shared row
+			 * line, which is what previously masked same-row chords
+			 * such as Shift/Symbol + N/M/-.
+			 */
+			gpiod_direction_output(kbd->out[i], 0);
 			udelay(100);
 			in[try][i] = 0;
 			err = gpiod_get_array_value(8, kbd->in, NULL, &in[try][i]);
 			if (err) {
 				dev_err(dev, "failed to get array value: %d\n", err);
 			}
-			in[try][i] = ~(((in[try][i] ^ (in[try][i] >> 1)) & 0x1f) ^ (in[try][i] >> 1)) & 0x7f;
-			gpiod_set_value(kbd->out[i], 0);
+			/*
+			 * Decode the raw read into a 7-bit per-column row mask
+			 * where a pressed key is 0 (active low). Input bit 5 is
+			 * unused; raw bits 6 and 7 map to rows 5 and 6.
+			 */
+			in[try][i] = (((in[try][i] ^ (in[try][i] >> 1)) & 0x1f) ^ (in[try][i] >> 1)) & 0x7f;
+			gpiod_direction_input(kbd->out[i]);
 		}
 
 		if (try < 3) {


### PR DESCRIPTION
_Disclaimer: I used AI heavily in this fix. I at least ensured that I understood everything it wrote._

# Background

For those who came across this PR in the future, here's the context.

## Symptom

As noted by [Nasubi on Discord](https://discord.com/channels/759813579120836608/770607973214584865/1486533775377829968) (machine-translated):

> On my Brain device:
> When I try to enter a "." by pressing the "Symbol" key and "M" simultaneously, the "." repeats continuously and won't stop until I press another key.
>
> Also, I just checked on my new Brain unit:
> When entering ",", ".", or "/", a repeat input almost always occurs.
> Regarding inputs other than ",", ".", or "/", the issue also occurred with "4" and "=".
> Other keys seem fine based on my current testing.
> 
> (It seems to happen with those specific keys even when pressed simultaneously with Shift—specifically the E, F, N, M, and - keys.)

As written in [this blog post](https://nsb.homeip.net/wp/?p=3003#%E3%82%AD%E3%83%BC%E3%83%9C%E3%83%BC%E3%83%89%E6%93%8D%E4%BD%9C%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6):

> I'm testing this on the PW-SH3, and sometimes the simultaneous key input for certain symbols (",", ".", "/") doesn't work right; even when the input registers, it often starts repeating endlessly for some reason.
> I'm not sure if other models have the same issue.
> In these cases, I deal with it by deleting the extra characters, but the only workaround I could think of to stop the repeating input was to immediately press another key.
> (For example, to enter ".", I might press Symbol+M followed by M—resulting in ".m"—and then delete the "m".)
> Since "." is frequently used for entering IP addresses and URLs, this is a bit frustrating.
> Sometimes the input works fine, but other times it gets recognized as a repeating input, and I haven't been able to control it properly so far.

## Context

Here's the actual Brain Row 4 (called "bank 0x10" in the code), from the device tree:

```
Row 4:  Col0=Shift   Col1=R   Col2=F   Col3=Symbol   Col4=N   Col5=M   Col6=Minus
```

**Both modifiers -- Shift AND Symbol -- physically live on Row 4**, together with N, M, and Minus.

# Root cause

The original code drove columns like this (simplified):

```
for each column c:
    drive column c HIGH      ← "activate"
    (all other columns stay driven LOW)
    read the rows
    drive column c LOW again
```

And the rows were read as: pressed = HIGH. The key idea the original relied on: when you drive column c HIGH, a pressed key on column c pulls its row HIGH, so you see it.

The problem: **the other columns were driven LOW the whole time**. They are actively forced to ground, not disconnected.

<img width="282" height="683" alt="image" src="https://github.com/user-attachments/assets/3817bd5b-f2a9-455d-a2eb-eb190e848c42" />

# The fix

Two coordinated changes.

## Change A: idle columns go hi-Z instead of LOW

New scan:

```
for each column c:
    drive column c LOW          ← "activate" (note: LOW now, see below)
    set all other columns to INPUT mode  ← hi-Z = disconnected!
    read the rows
    set column c back to INPUT mode (hi-Z)
```

## Change B: rows get pull-ups, and we flip the polarity

If idle columns are now *disconnected*, nothing holds a row wire at a defined value when none of its keys is pressed. It would **float**. On the device, it would appear as if all keys are dead.

We need to give those wires a "default value". We do this by **adding pull-up resistors to the row wires.** Now:

- **Key not pressed** → row floats up to HIGH via its pull-up → reads `1`.
- **Key pressed** → connects row to the scanned column, which we drive **LOW** → strong path to ground beats the weak pull-up → reads `0`.

So the logic flips to **active-low**: `0` now means pressed. (Before, with the drive-HIGH scheme, `1` meant pressed.)

That's why the active column is now driven **LOW** instead of HIGH: the pressed key needs to pull its pulled-up row *down* to be detected.

We **had** to flip the polarity because the i.MX28 has no pull-down resistors on these pins. Eviences:

1. **The binding doc** (`fsl,mxs-pinctrl.txt`) says, "The configuration on the pins includes drive strength, voltage **and pull-up**." No "pull-downs".

2. **The constants** in `mxs-pinfunc.h` only has two values, and notice they describe an *on/off switch*, not a *direction*:

```c
#define MXS_PULL_DISABLE	0
#define MXS_PULL_ENABLE		1
```

So we can only weakly pull up, not weekly pull down. So the default value can only be "1", not "0". Thus we need to make "0" represent the "pressed" state.